### PR TITLE
TDK-9019 Adding Bug fix in build.sh for Opensourced L1 HALs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ NC="\e[39m"
 # When the major version changes in the ut-core, what that signals is that the testings will have to be upgraded to support that version
 # Therefore in that case it warns you but doesnt' chnage to that version, which could cause your tests to break.
 # Change this to upgrade your UT-Core Major versions. Non ABI Changes 1.x.x are supported, between major revisions
-UT_PROJECT_MAJOR_VERSION="3."
+UT_PROJECT_MAJOR_VERSION="3.1.1"
 
 # Clone the Unit Test Requirements
 TEST_REPO=git@github.com:rdkcentral/ut-core.git
@@ -39,7 +39,7 @@ function check_next_revision()
     pushd ./ut-core
     # Set default UT_CORE_PROJECT_VERSION to next revision, if it's set then we don't need to tell you again
     if [ -v ${UT_CORE_PROJECT_VERSION} ]; then
-        UT_CORE_PROJECT_VERSION=$(git tag | grep ${UT_PROJECT_MAJOR_VERSION} | sort -r | head -n1)
+        UT_CORE_PROJECT_VERSION=$(git tag | grep ^${UT_PROJECT_MAJOR_VERSION} | sort -r | head -n1)
         UT_NEXT_VERSION=$(git tag | sort -r | head -n1)
         echo -e ${YELLOW}ut-core version selected:[${UT_CORE_PROJECT_VERSION}]${NC}
         if [ "${UT_NEXT_VERSION}" != "${UT_CORE_PROJECT_VERSION}" ]; then


### PR DESCRIPTION
Reason for change: Adding bug fix in build.sh for L1 cellular-modem HAL
Risks: Low
Test Procedure: Check the ticket